### PR TITLE
Daily script assertion & fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "site"
   ],
   "scripts": {
-    "casualties-daily": "yarn scripts/casualties-daily.ts",
+    "casualties-daily": "bun run scripts/casualties-daily.ts",
     "docs-start": "cd site && yarn start",
     "docs-build": "./scripts/pre-build.sh && cd site && yarn build && cd .. && ./scripts/pre-deploy.sh",
     "docs-serve": "cd site && yarn serve"


### PR DESCRIPTION
We have fields in the daily report that must be defined per our docs, so adding another step after we generate it to ensure those fields are defined. I have some checks setup in the source worksheet but it's more reliable to assert this when we generate the JSON.

Also fixing the script itself which I broke earlier.